### PR TITLE
Fix laravel 9.x.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,16 +22,16 @@
     "php": "^8.0",
     "ext-json": "*",
     "nunomaduro/larastan": "^2.0 || ^1.0",
-    "phpmd/phpmd": "2.12",
+    "phpmd/phpmd": "^2.12",
     "povils/phpmnd": "^3.0",
     "sebastian/phpcpd": "^6.0",
-    "slevomat/coding-standard": "^8.2",
-    "symplify/coding-standard": "^9.3",
-    "symplify/easy-coding-standard": "^9.4",
+    "slevomat/coding-standard": "^8.3",
+    "symplify/coding-standard": "^10.0",
+    "symplify/easy-coding-standard": "^10.0",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
     "phpstan/phpdoc-parser": "^1.0.0",
     "phpstan/phpstan": "^1.0",
-    "squizlabs/php_codesniffer": "^3.6.2"
+    "squizlabs/php_codesniffer": "^3.7.1"
   },
   "require-dev": {
     "orchestra/testbench": "^7.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ee99677eaaead768321c536b6fb721b0",
+    "content-hash": "42218157c7e4d11c2b816e9281223bd5",
     "packages": [
         {
             "name": "brick/math",
@@ -65,6 +65,79 @@
                 }
             ],
             "time": "2021-08-15T20:50:18+00:00"
+        },
+        {
+            "name": "composer/class-map-generator",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/class-map-generator.git",
+                "reference": "1e1cb2b791facb2dfe32932a7718cf2571187513"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/class-map-generator/zipball/1e1cb2b791facb2dfe32932a7718cf2571187513",
+                "reference": "1e1cb2b791facb2dfe32932a7718cf2571187513",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^2 || ^3",
+                "php": "^7.2 || ^8.0",
+                "symfony/finder": "^4.4 || ^5.3 || ^6"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.6",
+                "phpstan/phpstan-deprecation-rules": "^1",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "symfony/filesystem": "^5.4 || ^6",
+                "symfony/phpunit-bridge": "^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\ClassMapGenerator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Utilities to scan PHP code and generate class maps.",
+            "keywords": [
+                "classmap"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/class-map-generator/issues",
+                "source": "https://github.com/composer/class-map-generator/tree/1.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-06-19T11:31:27+00:00"
         },
         {
             "name": "composer/pcre",
@@ -283,66 +356,6 @@
                 }
             ],
             "time": "2022-02-25T21:32:43+00:00"
-        },
-        {
-            "name": "danielstjules/stringy",
-            "version": "3.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/danielstjules/Stringy.git",
-                "reference": "df24ab62d2d8213bbbe88cc36fc35a4503b4bd7e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/danielstjules/Stringy/zipball/df24ab62d2d8213bbbe88cc36fc35a4503b4bd7e",
-                "reference": "df24ab62d2d8213bbbe88cc36fc35a4503b4bd7e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0",
-                "symfony/polyfill-mbstring": "~1.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/Create.php"
-                ],
-                "psr-4": {
-                    "Stringy\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Daniel St. Jules",
-                    "email": "danielst.jules@gmail.com",
-                    "homepage": "http://www.danielstjules.com"
-                }
-            ],
-            "description": "A string manipulation library with multibyte support",
-            "homepage": "https://github.com/danielstjules/Stringy",
-            "keywords": [
-                "UTF",
-                "helpers",
-                "manipulation",
-                "methods",
-                "multibyte",
-                "string",
-                "utf-8",
-                "utility",
-                "utils"
-            ],
-            "support": {
-                "issues": "https://github.com/danielstjules/Stringy/issues",
-                "source": "https://github.com/danielstjules/Stringy"
-            },
-            "time": "2017-06-12T01:10:27+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -865,16 +878,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.9.3",
+            "version": "v3.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "bad87e63d7d87efa5e82aa4feafa52df6a37e6c1"
+                "reference": "093466b1c3ff3e3b469bdbc9827bb2362de6b2fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/bad87e63d7d87efa5e82aa4feafa52df6a37e6c1",
-                "reference": "bad87e63d7d87efa5e82aa4feafa52df6a37e6c1",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/093466b1c3ff3e3b469bdbc9827bb2362de6b2fa",
+                "reference": "093466b1c3ff3e3b469bdbc9827bb2362de6b2fa",
                 "shasum": ""
             },
             "require": {
@@ -942,7 +955,7 @@
             "description": "A tool to automatically fix PHP code style",
             "support": {
                 "issues": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues",
-                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v3.9.3"
+                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v3.9.4"
             },
             "funding": [
                 {
@@ -950,7 +963,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-07-13T09:53:20+00:00"
+            "time": "2022-07-15T21:04:49+00:00"
         },
         {
             "name": "fruitcake/php-cors",
@@ -1138,16 +1151,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v9.20.0",
+            "version": "v9.21.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "c99868f1c9bf2f5d250993121838db905591864f"
+                "reference": "a1944cd0d160a2cc423ef5a451d002711c5f014f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/c99868f1c9bf2f5d250993121838db905591864f",
-                "reference": "c99868f1c9bf2f5d250993121838db905591864f",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/a1944cd0d160a2cc423ef5a451d002711c5f014f",
+                "reference": "a1944cd0d160a2cc423ef5a451d002711c5f014f",
                 "shasum": ""
             },
             "require": {
@@ -1162,6 +1175,7 @@
                 "league/flysystem": "^3.0.16",
                 "monolog/monolog": "^2.0",
                 "nesbot/carbon": "^2.53.1",
+                "nunomaduro/termwind": "^1.13",
                 "php": "^8.0.2",
                 "psr/container": "^1.1.1|^2.0.1",
                 "psr/log": "^1.0|^2.0|^3.0",
@@ -1313,7 +1327,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-07-13T13:26:22+00:00"
+            "time": "2022-07-21T19:38:16+00:00"
         },
         {
             "name": "laravel/serializable-closure",
@@ -1376,16 +1390,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.3.3",
+            "version": "2.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "0da1dca5781dd3cfddbe328224d9a7a62571addc"
+                "reference": "155ec1c95626b16fda0889cf15904d24890a60d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/0da1dca5781dd3cfddbe328224d9a7a62571addc",
-                "reference": "0da1dca5781dd3cfddbe328224d9a7a62571addc",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/155ec1c95626b16fda0889cf15904d24890a60d5",
+                "reference": "155ec1c95626b16fda0889cf15904d24890a60d5",
                 "shasum": ""
             },
             "require": {
@@ -1478,7 +1492,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-07T21:28:26+00:00"
+            "time": "2022-07-17T16:25:47+00:00"
         },
         {
             "name": "league/config",
@@ -1564,16 +1578,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "34a68067b7ae3b836ea5e57e1fc432478372a4f5"
+                "reference": "1a941703dfb649f9b821e7bc425e782f576a805e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/34a68067b7ae3b836ea5e57e1fc432478372a4f5",
-                "reference": "34a68067b7ae3b836ea5e57e1fc432478372a4f5",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/1a941703dfb649f9b821e7bc425e782f576a805e",
+                "reference": "1a941703dfb649f9b821e7bc425e782f576a805e",
                 "shasum": ""
             },
             "require": {
@@ -1634,7 +1648,7 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.1.0"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.1.1"
             },
             "funding": [
                 {
@@ -1650,7 +1664,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-29T17:29:54+00:00"
+            "time": "2022-07-18T09:59:40+00:00"
         },
         {
             "name": "league/mime-type-detection",
@@ -1987,74 +2001,6 @@
             "time": "2022-06-29T21:43:55+00:00"
         },
         {
-            "name": "nette/neon",
-            "version": "v3.3.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nette/neon.git",
-                "reference": "22e384da162fab42961d48eb06c06d3ad0c11b95"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nette/neon/zipball/22e384da162fab42961d48eb06c06d3ad0c11b95",
-                "reference": "22e384da162fab42961d48eb06c06d3ad0c11b95",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "nette/tester": "^2.0",
-                "phpstan/phpstan": "^0.12",
-                "tracy/tracy": "^2.7"
-            },
-            "bin": [
-                "bin/neon-lint"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.3-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0-only",
-                "GPL-3.0-only"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                },
-                {
-                    "name": "Nette Community",
-                    "homepage": "https://nette.org/contributors"
-                }
-            ],
-            "description": "🍸 Nette NEON: encodes and decodes NEON file format.",
-            "homepage": "https://ne-on.org",
-            "keywords": [
-                "export",
-                "import",
-                "neon",
-                "nette",
-                "yaml"
-            ],
-            "support": {
-                "issues": "https://github.com/nette/neon/issues",
-                "source": "https://github.com/nette/neon/tree/v3.3.3"
-            },
-            "time": "2022-03-10T02:04:26+00:00"
-        },
-        {
             "name": "nette/schema",
             "version": "v1.2.2",
             "source": {
@@ -2259,19 +2205,20 @@
         },
         {
             "name": "nunomaduro/larastan",
-            "version": "v2.1.11",
+            "version": "v2.1.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/larastan.git",
-                "reference": "8514c5ec475b440702f08cf804e73cd55a05f622"
+                "reference": "65cfc54fa195e509c2e2be119761552017d22a56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/larastan/zipball/8514c5ec475b440702f08cf804e73cd55a05f622",
-                "reference": "8514c5ec475b440702f08cf804e73cd55a05f622",
+                "url": "https://api.github.com/repos/nunomaduro/larastan/zipball/65cfc54fa195e509c2e2be119761552017d22a56",
+                "reference": "65cfc54fa195e509c2e2be119761552017d22a56",
                 "shasum": ""
             },
             "require": {
+                "composer/class-map-generator": "^1.0",
                 "composer/pcre": "^3.0",
                 "ext-json": "*",
                 "illuminate/console": "^9",
@@ -2284,7 +2231,7 @@
                 "mockery/mockery": "^1.4.4",
                 "php": "^8.0.2",
                 "phpmyadmin/sql-parser": "^5.5",
-                "phpstan/phpstan": "^1.7.12"
+                "phpstan/phpstan": "^1.8.1"
             },
             "require-dev": {
                 "nikic/php-parser": "^4.13.2",
@@ -2333,7 +2280,7 @@
             ],
             "support": {
                 "issues": "https://github.com/nunomaduro/larastan/issues",
-                "source": "https://github.com/nunomaduro/larastan/tree/v2.1.11"
+                "source": "https://github.com/nunomaduro/larastan/tree/v2.1.12"
             },
             "funding": [
                 {
@@ -2353,7 +2300,93 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2022-06-13T21:45:42+00:00"
+            "time": "2022-07-17T15:23:33+00:00"
+        },
+        {
+            "name": "nunomaduro/termwind",
+            "version": "v1.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nunomaduro/termwind.git",
+                "reference": "132a24bd3e8c559e7f14fa14ba1b83772a0f97f8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/132a24bd3e8c559e7f14fa14ba1b83772a0f97f8",
+                "reference": "132a24bd3e8c559e7f14fa14ba1b83772a0f97f8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^8.0",
+                "symfony/console": "^5.3.0|^6.0.0"
+            },
+            "require-dev": {
+                "ergebnis/phpstan-rules": "^1.0.",
+                "illuminate/console": "^8.0|^9.0",
+                "illuminate/support": "^8.0|^9.0",
+                "laravel/pint": "^0.2.0",
+                "pestphp/pest": "^1.21.0",
+                "pestphp/pest-plugin-mock": "^1.0",
+                "phpstan/phpstan": "^1.4.6",
+                "phpstan/phpstan-strict-rules": "^1.1.0",
+                "symfony/var-dumper": "^5.2.7|^6.0.0",
+                "thecodingmachine/phpstan-strict-rules": "^1.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Termwind\\Laravel\\TermwindServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Functions.php"
+                ],
+                "psr-4": {
+                    "Termwind\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "Its like Tailwind CSS, but for the console.",
+            "keywords": [
+                "cli",
+                "console",
+                "css",
+                "package",
+                "php",
+                "style"
+            ],
+            "support": {
+                "issues": "https://github.com/nunomaduro/termwind/issues",
+                "source": "https://github.com/nunomaduro/termwind/tree/v1.13.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/xiCO2k",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-07-01T15:06:55+00:00"
         },
         {
             "name": "pdepend/pdepend",
@@ -2839,16 +2872,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.8.1",
+            "version": "1.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "8dbba631fa32f4b289404469c2afd6122fd61d67"
+                "reference": "c53312ecc575caf07b0e90dee43883fdf90ca67c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8dbba631fa32f4b289404469c2afd6122fd61d67",
-                "reference": "8dbba631fa32f4b289404469c2afd6122fd61d67",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c53312ecc575caf07b0e90dee43883fdf90ca67c",
+                "reference": "c53312ecc575caf07b0e90dee43883fdf90ca67c",
                 "shasum": ""
             },
             "require": {
@@ -2874,7 +2907,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.8.1"
+                "source": "https://github.com/phpstan/phpstan/tree/1.8.2"
             },
             "funding": [
                 {
@@ -2894,7 +2927,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-07-12T16:08:06+00:00"
+            "time": "2022-07-20T09:57:31+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3550,6 +3583,72 @@
             "time": "2020-09-28T06:08:49+00:00"
         },
         {
+            "name": "sebastian/diff",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:10:38+00:00"
+        },
+        {
             "name": "sebastian/phpcpd",
             "version": "6.0.3",
             "source": {
@@ -3665,16 +3764,16 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "8.2.0",
+            "version": "8.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "0cec515440c92735ce3cc35cfb0891d89080a72b"
+                "reference": "a14df437f2efe861ca9118508f304de9655957e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/0cec515440c92735ce3cc35cfb0891d89080a72b",
-                "reference": "0cec515440c92735ce3cc35cfb0891d89080a72b",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/a14df437f2efe861ca9118508f304de9655957e4",
+                "reference": "a14df437f2efe861ca9118508f304de9655957e4",
                 "shasum": ""
             },
             "require": {
@@ -3684,9 +3783,9 @@
                 "squizlabs/php_codesniffer": "^3.7.1"
             },
             "require-dev": {
-                "phing/phing": "2.17.3",
+                "phing/phing": "2.17.4",
                 "php-parallel-lint/php-parallel-lint": "1.3.2",
-                "phpstan/phpstan": "1.4.10|1.8.0",
+                "phpstan/phpstan": "1.4.10|1.8.1",
                 "phpstan/phpstan-deprecation-rules": "1.0.0",
                 "phpstan/phpstan-phpunit": "1.0.0|1.1.1",
                 "phpstan/phpstan-strict-rules": "1.3.0",
@@ -3710,7 +3809,7 @@
             "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/8.2.0"
+                "source": "https://github.com/slevomat/coding-standard/tree/8.3.0"
             },
             "funding": [
                 {
@@ -3722,7 +3821,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-07-08T09:51:40+00:00"
+            "time": "2022-07-16T11:59:39+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -6239,55 +6338,45 @@
         },
         {
             "name": "symplify/autowire-array-parameter",
-            "version": "9.4.70",
+            "version": "10.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/autowire-array-parameter.git",
-                "reference": "042e9ce31a7b8a0e66246ea0297147349ecaec60"
+                "reference": "e3ca795122712fab224a5c10339b1fb278505420"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/autowire-array-parameter/zipball/042e9ce31a7b8a0e66246ea0297147349ecaec60",
-                "reference": "042e9ce31a7b8a0e66246ea0297147349ecaec60",
+                "url": "https://api.github.com/repos/symplify/autowire-array-parameter/zipball/e3ca795122712fab224a5c10339b1fb278505420",
+                "reference": "e3ca795122712fab224a5c10339b1fb278505420",
                 "shasum": ""
             },
             "require": {
                 "nette/utils": "^3.2",
                 "php": ">=8.0",
-                "symfony/dependency-injection": "^5.3|^6.0",
-                "symplify/package-builder": "^9.4.70"
+                "symfony/dependency-injection": "^6.0",
+                "symplify/package-builder": "^10.3.3"
             },
             "conflict": {
-                "symplify/amnesia": "<9.4.70",
-                "symplify/astral": "<9.4.70",
-                "symplify/coding-standard": "<9.4.70",
-                "symplify/composer-json-manipulator": "<9.4.70",
-                "symplify/config-transformer": "<9.4.70",
-                "symplify/console-color-diff": "<9.4.70",
-                "symplify/console-package-builder": "<9.4.70",
-                "symplify/easy-ci": "<9.4.70",
-                "symplify/easy-coding-standard": "<9.4.70",
-                "symplify/easy-hydrator": "<9.4.70",
-                "symplify/easy-testing": "<9.4.70",
-                "symplify/git-wrapper": "<9.4.70",
-                "symplify/latte-phpstan-compiler": "<9.4.70",
-                "symplify/markdown-diff": "<9.4.70",
-                "symplify/monorepo-builder": "<9.4.70",
-                "symplify/php-config-printer": "<9.4.70",
-                "symplify/phpstan-extensions": "<9.4.70",
-                "symplify/phpstan-rules": "<9.4.70",
-                "symplify/psr4-switcher": "<9.4.70",
-                "symplify/rule-doc-generator": "<9.4.70",
-                "symplify/rule-doc-generator-contracts": "<9.4.70",
-                "symplify/simple-php-doc-parser": "<9.4.70",
-                "symplify/skipper": "<9.4.70",
-                "symplify/smart-file-system": "<9.4.70",
-                "symplify/symfony-php-config": "<9.4.70",
-                "symplify/symfony-static-dumper": "<9.4.70",
-                "symplify/symplify-kernel": "<9.4.70",
-                "symplify/template-phpstan-compiler": "<9.4.70",
-                "symplify/twig-phpstan-compiler": "<9.4.70",
-                "symplify/vendor-patches": "<9.4.70"
+                "symplify/astral": "<10.3.3",
+                "symplify/coding-standard": "<10.3.3",
+                "symplify/composer-json-manipulator": "<10.3.3",
+                "symplify/config-transformer": "<10.3.3",
+                "symplify/easy-ci": "<10.3.3",
+                "symplify/easy-coding-standard": "<10.3.3",
+                "symplify/easy-parallel": "<10.3.3",
+                "symplify/easy-testing": "<10.3.3",
+                "symplify/monorepo-builder": "<10.3.3",
+                "symplify/neon-config-dumper": "<10.3.3",
+                "symplify/php-config-printer": "<10.3.3",
+                "symplify/phpstan-extensions": "<10.3.3",
+                "symplify/phpstan-rules": "<10.3.3",
+                "symplify/rule-doc-generator": "<10.3.3",
+                "symplify/rule-doc-generator-contracts": "<10.3.3",
+                "symplify/skipper": "<10.3.3",
+                "symplify/smart-file-system": "<10.3.3",
+                "symplify/symfony-static-dumper": "<10.3.3",
+                "symplify/symplify-kernel": "<10.3.3",
+                "symplify/vendor-patches": "<10.3.3"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -6295,7 +6384,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "9.5-dev"
+                    "dev-main": "10.4-dev"
                 }
             },
             "autoload": {
@@ -6309,7 +6398,7 @@
             ],
             "description": "Autowire array parameters for your Symfony applications",
             "support": {
-                "source": "https://github.com/symplify/autowire-array-parameter/tree/9.4.70"
+                "source": "https://github.com/symplify/autowire-array-parameter/tree/10.3.3"
             },
             "funding": [
                 {
@@ -6321,75 +6410,72 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-10-02T16:05:32+00:00"
+            "time": "2022-06-13T14:05:31+00:00"
         },
         {
             "name": "symplify/coding-standard",
-            "version": "9.4.70",
+            "version": "10.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/coding-standard.git",
-                "reference": "90aa7b1180187c575243ac781cec4d220b748f67"
+                "reference": "07e8a9f67dd74ede6038dc70750654449e80e9ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/coding-standard/zipball/90aa7b1180187c575243ac781cec4d220b748f67",
-                "reference": "90aa7b1180187c575243ac781cec4d220b748f67",
+                "url": "https://api.github.com/repos/symplify/coding-standard/zipball/07e8a9f67dd74ede6038dc70750654449e80e9ab",
+                "reference": "07e8a9f67dd74ede6038dc70750654449e80e9ab",
                 "shasum": ""
             },
             "require": {
-                "friendsofphp/php-cs-fixer": "^3.1",
+                "friendsofphp/php-cs-fixer": "^3.8",
                 "nette/utils": "^3.2",
                 "php": ">=8.0",
-                "symplify/autowire-array-parameter": "^9.4.70",
-                "symplify/package-builder": "^9.4.70",
-                "symplify/rule-doc-generator-contracts": "^9.4.70",
-                "symplify/symplify-kernel": "^9.4.70"
+                "symplify/autowire-array-parameter": "^10.3.3",
+                "symplify/package-builder": "^10.3.3",
+                "symplify/rule-doc-generator-contracts": "^10.3.3",
+                "symplify/symplify-kernel": "^10.3.3"
             },
             "conflict": {
-                "symplify/amnesia": "<9.4.70",
-                "symplify/astral": "<9.4.70",
-                "symplify/composer-json-manipulator": "<9.4.70",
-                "symplify/config-transformer": "<9.4.70",
-                "symplify/console-color-diff": "<9.4.70",
-                "symplify/console-package-builder": "<9.4.70",
-                "symplify/easy-ci": "<9.4.70",
-                "symplify/easy-coding-standard": "<9.4.70",
-                "symplify/easy-hydrator": "<9.4.70",
-                "symplify/easy-testing": "<9.4.70",
-                "symplify/git-wrapper": "<9.4.70",
-                "symplify/latte-phpstan-compiler": "<9.4.70",
-                "symplify/markdown-diff": "<9.4.70",
-                "symplify/monorepo-builder": "<9.4.70",
-                "symplify/php-config-printer": "<9.4.70",
-                "symplify/phpstan-extensions": "<9.4.70",
-                "symplify/phpstan-rules": "<9.4.70",
-                "symplify/psr4-switcher": "<9.4.70",
-                "symplify/rule-doc-generator": "<9.4.70",
-                "symplify/simple-php-doc-parser": "<9.4.70",
-                "symplify/skipper": "<9.4.70",
-                "symplify/smart-file-system": "<9.4.70",
-                "symplify/symfony-php-config": "<9.4.70",
-                "symplify/symfony-static-dumper": "<9.4.70",
-                "symplify/template-phpstan-compiler": "<9.4.70",
-                "symplify/twig-phpstan-compiler": "<9.4.70",
-                "symplify/vendor-patches": "<9.4.70"
+                "symplify/astral": "<10.3.3",
+                "symplify/composer-json-manipulator": "<10.3.3",
+                "symplify/config-transformer": "<10.3.3",
+                "symplify/easy-ci": "<10.3.3",
+                "symplify/easy-coding-standard": "<10.3.3",
+                "symplify/easy-parallel": "<10.3.3",
+                "symplify/easy-testing": "<10.3.3",
+                "symplify/monorepo-builder": "<10.3.3",
+                "symplify/neon-config-dumper": "<10.3.3",
+                "symplify/php-config-printer": "<10.3.3",
+                "symplify/phpstan-extensions": "<10.3.3",
+                "symplify/phpstan-rules": "<10.3.3",
+                "symplify/rule-doc-generator": "<10.3.3",
+                "symplify/skipper": "<10.3.3",
+                "symplify/smart-file-system": "<10.3.3",
+                "symplify/symfony-static-dumper": "<10.3.3",
+                "symplify/vendor-patches": "<10.3.3"
             },
             "require-dev": {
-                "doctrine/orm": "^2.9",
+                "cweagans/composer-patches": "^1.7",
+                "doctrine/orm": "^2.10",
                 "nette/application": "^3.1",
                 "nette/bootstrap": "^3.1",
                 "phpunit/phpunit": "^9.5",
-                "symfony/framework-bundle": "^5.3|^6.0",
-                "symfony/http-kernel": "^5.3|^6.0",
-                "symplify/easy-coding-standard": "^9.4.70",
-                "symplify/rule-doc-generator": "^9.4.70",
-                "symplify/smart-file-system": "^9.4.70"
+                "symfony/framework-bundle": "^6.0",
+                "symplify/easy-coding-standard": "^10.3.3",
+                "symplify/rule-doc-generator": "^10.3.3",
+                "symplify/smart-file-system": "^10.3.3",
+                "symplify/symplify-kernel": "^10.3.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "9.5-dev"
+                    "dev-main": "10.4-dev"
+                },
+                "enable-patching": true,
+                "patches": {
+                    "symfony/dependency-injection": [
+                        "https://raw.githubusercontent.com/symplify/vendor-patch-files/main/patches/generic-php-config-loader.patch"
+                    ]
                 }
             },
             "autoload": {
@@ -6403,7 +6489,7 @@
             ],
             "description": "Set of Symplify rules for PHP_CodeSniffer and PHP CS Fixer.",
             "support": {
-                "source": "https://github.com/symplify/coding-standard/tree/9.4.70"
+                "source": "https://github.com/symplify/coding-standard/tree/10.3.3"
             },
             "funding": [
                 {
@@ -6415,62 +6501,52 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-10-02T16:05:47+00:00"
+            "time": "2022-06-13T14:05:35+00:00"
         },
         {
             "name": "symplify/composer-json-manipulator",
-            "version": "9.4.70",
+            "version": "10.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/composer-json-manipulator.git",
-                "reference": "e3e5c38e38e2f7fcb86e8ac869a4e9d0d626c655"
+                "reference": "84f716bd543d946921c4ef6d2197a9f2877c7691"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/composer-json-manipulator/zipball/e3e5c38e38e2f7fcb86e8ac869a4e9d0d626c655",
-                "reference": "e3e5c38e38e2f7fcb86e8ac869a4e9d0d626c655",
+                "url": "https://api.github.com/repos/symplify/composer-json-manipulator/zipball/84f716bd543d946921c4ef6d2197a9f2877c7691",
+                "reference": "84f716bd543d946921c4ef6d2197a9f2877c7691",
                 "shasum": ""
             },
             "require": {
                 "nette/utils": "^3.2",
                 "php": ">=8.0",
-                "symfony/config": "^5.3|^6.0",
-                "symfony/dependency-injection": "^5.3|^6.0",
-                "symfony/filesystem": "^5.3|^6.0",
-                "symfony/http-kernel": "^5.3|^6.0",
-                "symplify/package-builder": "^9.4.70",
-                "symplify/smart-file-system": "^9.4.70"
+                "symfony/config": "^6.0",
+                "symfony/dependency-injection": "^6.0",
+                "symfony/filesystem": "^6.0",
+                "symplify/package-builder": "^10.3.3",
+                "symplify/smart-file-system": "^10.3.3",
+                "symplify/symplify-kernel": "^10.3.3"
             },
             "conflict": {
-                "symplify/amnesia": "<9.4.70",
-                "symplify/astral": "<9.4.70",
-                "symplify/autowire-array-parameter": "<9.4.70",
-                "symplify/coding-standard": "<9.4.70",
-                "symplify/config-transformer": "<9.4.70",
-                "symplify/console-color-diff": "<9.4.70",
-                "symplify/console-package-builder": "<9.4.70",
-                "symplify/easy-ci": "<9.4.70",
-                "symplify/easy-coding-standard": "<9.4.70",
-                "symplify/easy-hydrator": "<9.4.70",
-                "symplify/easy-testing": "<9.4.70",
-                "symplify/git-wrapper": "<9.4.70",
-                "symplify/latte-phpstan-compiler": "<9.4.70",
-                "symplify/markdown-diff": "<9.4.70",
-                "symplify/monorepo-builder": "<9.4.70",
-                "symplify/php-config-printer": "<9.4.70",
-                "symplify/phpstan-extensions": "<9.4.70",
-                "symplify/phpstan-rules": "<9.4.70",
-                "symplify/psr4-switcher": "<9.4.70",
-                "symplify/rule-doc-generator": "<9.4.70",
-                "symplify/rule-doc-generator-contracts": "<9.4.70",
-                "symplify/simple-php-doc-parser": "<9.4.70",
-                "symplify/skipper": "<9.4.70",
-                "symplify/symfony-php-config": "<9.4.70",
-                "symplify/symfony-static-dumper": "<9.4.70",
+                "symplify/astral": "<10.3.3",
+                "symplify/autowire-array-parameter": "<10.3.3",
+                "symplify/coding-standard": "<10.3.3",
+                "symplify/config-transformer": "<10.3.3",
+                "symplify/easy-ci": "<10.3.3",
+                "symplify/easy-coding-standard": "<10.3.3",
+                "symplify/easy-parallel": "<10.3.3",
+                "symplify/easy-testing": "<10.3.3",
+                "symplify/monorepo-builder": "<10.3.3",
+                "symplify/neon-config-dumper": "<10.3.3",
+                "symplify/php-config-printer": "<10.3.3",
+                "symplify/phpstan-extensions": "<10.3.3",
+                "symplify/phpstan-rules": "<10.3.3",
+                "symplify/rule-doc-generator": "<10.3.3",
+                "symplify/rule-doc-generator-contracts": "<10.3.3",
+                "symplify/skipper": "<10.3.3",
+                "symplify/symfony-static-dumper": "<10.3.3",
                 "symplify/symplify-kernel": "<9.4.70",
-                "symplify/template-phpstan-compiler": "<9.4.70",
-                "symplify/twig-phpstan-compiler": "<9.4.70",
-                "symplify/vendor-patches": "<9.4.70"
+                "symplify/vendor-patches": "<10.3.3"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -6478,7 +6554,7 @@
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "9.5-dev"
+                    "dev-main": "10.4-dev"
                 }
             },
             "autoload": {
@@ -6492,7 +6568,7 @@
             ],
             "description": "Package to load, merge and save composer.json file(s)",
             "support": {
-                "source": "https://github.com/symplify/composer-json-manipulator/tree/9.4.70"
+                "source": "https://github.com/symplify/composer-json-manipulator/tree/10.3.3"
             },
             "funding": [
                 {
@@ -6504,103 +6580,24 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-10-02T16:05:46+00:00"
-        },
-        {
-            "name": "symplify/console-package-builder",
-            "version": "9.4.70",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symplify/console-package-builder.git",
-                "reference": "cd99847c2258122926c9903589a742383b3eeba7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symplify/console-package-builder/zipball/cd99847c2258122926c9903589a742383b3eeba7",
-                "reference": "cd99847c2258122926c9903589a742383b3eeba7",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0",
-                "symfony/console": "^5.3|^6.0",
-                "symfony/dependency-injection": "^5.3|^6.0",
-                "symplify/symplify-kernel": "^9.4.70"
-            },
-            "conflict": {
-                "symplify/amnesia": "<9.4.70",
-                "symplify/astral": "<9.4.70",
-                "symplify/autowire-array-parameter": "<9.4.70",
-                "symplify/coding-standard": "<9.4.70",
-                "symplify/composer-json-manipulator": "<9.4.70",
-                "symplify/config-transformer": "<9.4.70",
-                "symplify/console-color-diff": "<9.4.70",
-                "symplify/easy-ci": "<9.4.70",
-                "symplify/easy-coding-standard": "<9.4.70",
-                "symplify/easy-hydrator": "<9.4.70",
-                "symplify/easy-testing": "<9.4.70",
-                "symplify/git-wrapper": "<9.4.70",
-                "symplify/latte-phpstan-compiler": "<9.4.70",
-                "symplify/markdown-diff": "<9.4.70",
-                "symplify/monorepo-builder": "<9.4.70",
-                "symplify/package-builder": "<9.4.70",
-                "symplify/php-config-printer": "<9.4.70",
-                "symplify/phpstan-extensions": "<9.4.70",
-                "symplify/phpstan-rules": "<9.4.70",
-                "symplify/psr4-switcher": "<9.4.70",
-                "symplify/rule-doc-generator": "<9.4.70",
-                "symplify/rule-doc-generator-contracts": "<9.4.70",
-                "symplify/simple-php-doc-parser": "<9.4.70",
-                "symplify/skipper": "<9.4.70",
-                "symplify/smart-file-system": "<9.4.70",
-                "symplify/symfony-php-config": "<9.4.70",
-                "symplify/symfony-static-dumper": "<9.4.70",
-                "symplify/template-phpstan-compiler": "<9.4.70",
-                "symplify/twig-phpstan-compiler": "<9.4.70",
-                "symplify/vendor-patches": "<9.4.70"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.5",
-                "symfony/http-kernel": "^5.3|^6.0",
-                "symplify/package-builder": "^9.4.70"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "9.5-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symplify\\ConsolePackageBuilder\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Package to speed up building command line applications",
-            "support": {
-                "source": "https://github.com/symplify/console-package-builder/tree/9.4.70"
-            },
-            "abandoned": "symplify/package-builder",
-            "time": "2021-10-02T16:05:49+00:00"
+            "time": "2022-06-13T14:06:01+00:00"
         },
         {
             "name": "symplify/easy-coding-standard",
-            "version": "9.4.70",
+            "version": "10.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/easy-coding-standard.git",
-                "reference": "9276b0c7a1a5671fc4a067656ab40d0aea42aaca"
+                "reference": "c93878b3c052321231519b6540e227380f90be17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/easy-coding-standard/zipball/9276b0c7a1a5671fc4a067656ab40d0aea42aaca",
-                "reference": "9276b0c7a1a5671fc4a067656ab40d0aea42aaca",
+                "url": "https://api.github.com/repos/symplify/easy-coding-standard/zipball/c93878b3c052321231519b6540e227380f90be17",
+                "reference": "c93878b3c052321231519b6540e227380f90be17",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "conflict": {
                 "friendsofphp/php-cs-fixer": "<3.0",
@@ -6612,7 +6609,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "9.5-dev"
+                    "dev-main": "10.3-dev"
                 }
             },
             "autoload": {
@@ -6626,7 +6623,7 @@
             ],
             "description": "Prefixed scoped version of ECS package",
             "support": {
-                "source": "https://github.com/symplify/easy-coding-standard/tree/9.4.70"
+                "source": "https://github.com/symplify/easy-coding-standard/tree/10.3.3"
             },
             "funding": [
                 {
@@ -6638,62 +6635,51 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-10-02T16:09:04+00:00"
+            "time": "2022-06-13T14:03:37+00:00"
         },
         {
             "name": "symplify/easy-testing",
-            "version": "9.4.70",
+            "version": "10.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/easy-testing.git",
-                "reference": "915097b3e5686ec6219c61d37c06e9aee71379d8"
+                "reference": "d4a78c8d55282143754d9be0d9577865394c073c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/easy-testing/zipball/915097b3e5686ec6219c61d37c06e9aee71379d8",
-                "reference": "915097b3e5686ec6219c61d37c06e9aee71379d8",
+                "url": "https://api.github.com/repos/symplify/easy-testing/zipball/d4a78c8d55282143754d9be0d9577865394c073c",
+                "reference": "d4a78c8d55282143754d9be0d9577865394c073c",
                 "shasum": ""
             },
             "require": {
                 "nette/utils": "^3.2",
                 "php": ">=8.0",
-                "symfony/console": "^5.3|^6.0",
-                "symfony/dependency-injection": "^5.3|^6.0",
-                "symfony/finder": "^5.3|^6.0",
-                "symfony/http-kernel": "^5.3|^6.0",
-                "symplify/console-package-builder": "^9.4.70",
-                "symplify/package-builder": "^9.4.70",
-                "symplify/smart-file-system": "^9.4.70",
-                "symplify/symplify-kernel": "^9.4.70"
+                "symfony/console": "^6.0",
+                "symfony/dependency-injection": "^6.0",
+                "symfony/finder": "^6.0",
+                "symplify/package-builder": "^10.3.3",
+                "symplify/smart-file-system": "^10.3.3",
+                "symplify/symplify-kernel": "^10.3.3"
             },
             "conflict": {
-                "symplify/amnesia": "<9.4.70",
-                "symplify/astral": "<9.4.70",
-                "symplify/autowire-array-parameter": "<9.4.70",
-                "symplify/coding-standard": "<9.4.70",
-                "symplify/composer-json-manipulator": "<9.4.70",
-                "symplify/config-transformer": "<9.4.70",
-                "symplify/console-color-diff": "<9.4.70",
-                "symplify/easy-ci": "<9.4.70",
-                "symplify/easy-coding-standard": "<9.4.70",
-                "symplify/easy-hydrator": "<9.4.70",
-                "symplify/git-wrapper": "<9.4.70",
-                "symplify/latte-phpstan-compiler": "<9.4.70",
-                "symplify/markdown-diff": "<9.4.70",
-                "symplify/monorepo-builder": "<9.4.70",
-                "symplify/php-config-printer": "<9.4.70",
-                "symplify/phpstan-extensions": "<9.4.70",
-                "symplify/phpstan-rules": "<9.4.70",
-                "symplify/psr4-switcher": "<9.4.70",
-                "symplify/rule-doc-generator": "<9.4.70",
-                "symplify/rule-doc-generator-contracts": "<9.4.70",
-                "symplify/simple-php-doc-parser": "<9.4.70",
-                "symplify/skipper": "<9.4.70",
-                "symplify/symfony-php-config": "<9.4.70",
-                "symplify/symfony-static-dumper": "<9.4.70",
-                "symplify/template-phpstan-compiler": "<9.4.70",
-                "symplify/twig-phpstan-compiler": "<9.4.70",
-                "symplify/vendor-patches": "<9.4.70"
+                "symplify/astral": "<10.3.3",
+                "symplify/autowire-array-parameter": "<10.3.3",
+                "symplify/coding-standard": "<10.3.3",
+                "symplify/composer-json-manipulator": "<10.3.3",
+                "symplify/config-transformer": "<10.3.3",
+                "symplify/easy-ci": "<10.3.3",
+                "symplify/easy-coding-standard": "<10.3.3",
+                "symplify/easy-parallel": "<10.3.3",
+                "symplify/monorepo-builder": "<10.3.3",
+                "symplify/neon-config-dumper": "<10.3.3",
+                "symplify/php-config-printer": "<10.3.3",
+                "symplify/phpstan-extensions": "<10.3.3",
+                "symplify/phpstan-rules": "<10.3.3",
+                "symplify/rule-doc-generator": "<10.3.3",
+                "symplify/rule-doc-generator-contracts": "<10.3.3",
+                "symplify/skipper": "<10.3.3",
+                "symplify/symfony-static-dumper": "<10.3.3",
+                "symplify/vendor-patches": "<10.3.3"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -6704,7 +6690,7 @@
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "9.5-dev"
+                    "dev-main": "10.4-dev"
                 }
             },
             "autoload": {
@@ -6718,7 +6704,7 @@
             ],
             "description": "Testing made easy",
             "support": {
-                "source": "https://github.com/symplify/easy-testing/tree/9.4.70"
+                "source": "https://github.com/symplify/easy-testing/tree/10.3.3"
             },
             "funding": [
                 {
@@ -6730,64 +6716,53 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-10-02T16:06:05+00:00"
+            "time": "2022-06-13T14:05:39+00:00"
         },
         {
             "name": "symplify/package-builder",
-            "version": "9.4.70",
+            "version": "10.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/package-builder.git",
-                "reference": "da7641674c9d044f804b8fb627122a6f9b030e61"
+                "reference": "bc785e064429f2341d035cc88cc954a56f220040"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/package-builder/zipball/da7641674c9d044f804b8fb627122a6f9b030e61",
-                "reference": "da7641674c9d044f804b8fb627122a6f9b030e61",
+                "url": "https://api.github.com/repos/symplify/package-builder/zipball/bc785e064429f2341d035cc88cc954a56f220040",
+                "reference": "bc785e064429f2341d035cc88cc954a56f220040",
                 "shasum": ""
             },
             "require": {
-                "nette/neon": "^3.2",
                 "nette/utils": "^3.2",
                 "php": ">=8.0",
-                "symfony/config": "^5.3|^6.0",
-                "symfony/console": "^5.3|^6.0",
-                "symfony/dependency-injection": "^5.3|^6.0",
-                "symfony/finder": "^5.3|^6.0",
-                "symfony/http-kernel": "^5.3|^6.0",
-                "symplify/easy-testing": "^9.4.70",
-                "symplify/symplify-kernel": "^9.4.70"
+                "sebastian/diff": "^4.0",
+                "symfony/config": "^6.0",
+                "symfony/console": "^6.0",
+                "symfony/dependency-injection": "^6.0",
+                "symfony/finder": "^6.0",
+                "symplify/easy-testing": "^10.3.3",
+                "symplify/symplify-kernel": "^10.3.3"
             },
             "conflict": {
-                "symplify/amnesia": "<9.4.70",
-                "symplify/astral": "<9.4.70",
-                "symplify/autowire-array-parameter": "<9.4.70",
-                "symplify/coding-standard": "<9.4.70",
-                "symplify/composer-json-manipulator": "<9.4.70",
-                "symplify/config-transformer": "<9.4.70",
-                "symplify/console-color-diff": "<9.4.70",
-                "symplify/console-package-builder": "<9.4.70",
-                "symplify/easy-ci": "<9.4.70",
-                "symplify/easy-coding-standard": "<9.4.70",
-                "symplify/easy-hydrator": "<9.4.70",
-                "symplify/git-wrapper": "<9.4.70",
-                "symplify/latte-phpstan-compiler": "<9.4.70",
-                "symplify/markdown-diff": "<9.4.70",
-                "symplify/monorepo-builder": "<9.4.70",
-                "symplify/php-config-printer": "<9.4.70",
-                "symplify/phpstan-extensions": "<9.4.70",
-                "symplify/phpstan-rules": "<9.4.70",
-                "symplify/psr4-switcher": "<9.4.70",
-                "symplify/rule-doc-generator": "<9.4.70",
-                "symplify/rule-doc-generator-contracts": "<9.4.70",
-                "symplify/simple-php-doc-parser": "<9.4.70",
-                "symplify/skipper": "<9.4.70",
-                "symplify/smart-file-system": "<9.4.70",
-                "symplify/symfony-php-config": "<9.4.70",
-                "symplify/symfony-static-dumper": "<9.4.70",
-                "symplify/template-phpstan-compiler": "<9.4.70",
-                "symplify/twig-phpstan-compiler": "<9.4.70",
-                "symplify/vendor-patches": "<9.4.70"
+                "symplify/astral": "<10.3.3",
+                "symplify/autowire-array-parameter": "<10.3.3",
+                "symplify/coding-standard": "<10.3.3",
+                "symplify/composer-json-manipulator": "<10.3.3",
+                "symplify/config-transformer": "<10.3.3",
+                "symplify/easy-ci": "<10.3.3",
+                "symplify/easy-coding-standard": "<10.3.3",
+                "symplify/easy-parallel": "<10.3.3",
+                "symplify/monorepo-builder": "<10.3.3",
+                "symplify/neon-config-dumper": "<10.3.3",
+                "symplify/php-config-printer": "<10.3.3",
+                "symplify/phpstan-extensions": "<10.3.3",
+                "symplify/phpstan-rules": "<10.3.3",
+                "symplify/rule-doc-generator": "<10.3.3",
+                "symplify/rule-doc-generator-contracts": "<10.3.3",
+                "symplify/skipper": "<10.3.3",
+                "symplify/smart-file-system": "<10.3.3",
+                "symplify/symfony-static-dumper": "<10.3.3",
+                "symplify/vendor-patches": "<10.3.3"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -6795,7 +6770,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "9.5-dev"
+                    "dev-main": "10.4-dev"
                 }
             },
             "autoload": {
@@ -6809,7 +6784,7 @@
             ],
             "description": "Dependency Injection, Console and Kernel toolkit for Symplify packages.",
             "support": {
-                "source": "https://github.com/symplify/package-builder/tree/9.4.70"
+                "source": "https://github.com/symplify/package-builder/tree/10.3.3"
             },
             "funding": [
                 {
@@ -6821,64 +6796,53 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-10-02T16:06:23+00:00"
+            "time": "2022-06-13T14:05:45+00:00"
         },
         {
             "name": "symplify/rule-doc-generator-contracts",
-            "version": "9.4.70",
+            "version": "10.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/rule-doc-generator-contracts.git",
-                "reference": "1f6ea1652dbb52d4f867f159ac12d59540f04e21"
+                "reference": "6c5f2661fdd9a290d455b31aa3619c80702119cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/rule-doc-generator-contracts/zipball/1f6ea1652dbb52d4f867f159ac12d59540f04e21",
-                "reference": "1f6ea1652dbb52d4f867f159ac12d59540f04e21",
+                "url": "https://api.github.com/repos/symplify/rule-doc-generator-contracts/zipball/6c5f2661fdd9a290d455b31aa3619c80702119cd",
+                "reference": "6c5f2661fdd9a290d455b31aa3619c80702119cd",
                 "shasum": ""
             },
             "require": {
-                "danielstjules/stringy": "^3.1",
                 "nette/utils": "^3.2",
                 "php": ">=8.0"
             },
             "conflict": {
-                "symplify/amnesia": "<9.4.70",
-                "symplify/astral": "<9.4.70",
-                "symplify/autowire-array-parameter": "<9.4.70",
-                "symplify/coding-standard": "<9.4.70",
-                "symplify/composer-json-manipulator": "<9.4.70",
-                "symplify/config-transformer": "<9.4.70",
-                "symplify/console-color-diff": "<9.4.70",
-                "symplify/console-package-builder": "<9.4.70",
-                "symplify/easy-ci": "<9.4.70",
-                "symplify/easy-coding-standard": "<9.4.70",
-                "symplify/easy-hydrator": "<9.4.70",
-                "symplify/easy-testing": "<9.4.70",
-                "symplify/git-wrapper": "<9.4.70",
-                "symplify/latte-phpstan-compiler": "<9.4.70",
-                "symplify/markdown-diff": "<9.4.70",
-                "symplify/monorepo-builder": "<9.4.70",
-                "symplify/package-builder": "<9.4.70",
-                "symplify/php-config-printer": "<9.4.70",
-                "symplify/phpstan-extensions": "<9.4.70",
-                "symplify/phpstan-rules": "<9.4.70",
-                "symplify/psr4-switcher": "<9.4.70",
-                "symplify/rule-doc-generator": "<9.4.70",
-                "symplify/simple-php-doc-parser": "<9.4.70",
-                "symplify/skipper": "<9.4.70",
-                "symplify/smart-file-system": "<9.4.70",
-                "symplify/symfony-php-config": "<9.4.70",
-                "symplify/symfony-static-dumper": "<9.4.70",
-                "symplify/symplify-kernel": "<9.4.70",
-                "symplify/template-phpstan-compiler": "<9.4.70",
-                "symplify/twig-phpstan-compiler": "<9.4.70",
-                "symplify/vendor-patches": "<9.4.70"
+                "symplify/astral": "<10.3.3",
+                "symplify/autowire-array-parameter": "<10.3.3",
+                "symplify/coding-standard": "<10.3.3",
+                "symplify/composer-json-manipulator": "<10.3.3",
+                "symplify/config-transformer": "<10.3.3",
+                "symplify/easy-ci": "<10.3.3",
+                "symplify/easy-coding-standard": "<10.3.3",
+                "symplify/easy-parallel": "<10.3.3",
+                "symplify/easy-testing": "<10.3.3",
+                "symplify/monorepo-builder": "<10.3.3",
+                "symplify/neon-config-dumper": "<10.3.3",
+                "symplify/package-builder": "<10.3.3",
+                "symplify/php-config-printer": "<10.3.3",
+                "symplify/phpstan-extensions": "<10.3.3",
+                "symplify/phpstan-rules": "<10.3.3",
+                "symplify/rule-doc-generator": "<10.3.3",
+                "symplify/skipper": "<10.3.3",
+                "symplify/smart-file-system": "<10.3.3",
+                "symplify/symfony-static-dumper": "<10.3.3",
+                "symplify/symplify-kernel": "<10.3.3",
+                "symplify/vendor-patches": "<10.3.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "9.5-dev"
+                    "dev-main": "10.4-dev"
                 }
             },
             "autoload": {
@@ -6892,7 +6856,7 @@
             ],
             "description": "Contracts for production code of RuleDocGenerator",
             "support": {
-                "source": "https://github.com/symplify/rule-doc-generator-contracts/tree/9.4.70"
+                "source": "https://github.com/symplify/rule-doc-generator-contracts/tree/10.3.3"
             },
             "funding": [
                 {
@@ -6904,60 +6868,50 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-10-02T16:05:23+00:00"
+            "time": "2022-06-13T14:03:35+00:00"
         },
         {
             "name": "symplify/smart-file-system",
-            "version": "9.4.70",
+            "version": "10.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/smart-file-system.git",
-                "reference": "bc9caf6258dabedc032aad4041bc58fd322aa660"
+                "reference": "0b465fcf7490ac89708510551a044961b9124493"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/smart-file-system/zipball/bc9caf6258dabedc032aad4041bc58fd322aa660",
-                "reference": "bc9caf6258dabedc032aad4041bc58fd322aa660",
+                "url": "https://api.github.com/repos/symplify/smart-file-system/zipball/0b465fcf7490ac89708510551a044961b9124493",
+                "reference": "0b465fcf7490ac89708510551a044961b9124493",
                 "shasum": ""
             },
             "require": {
                 "nette/utils": "^3.2",
                 "php": ">=8.0",
-                "symfony/filesystem": "^5.3|^6.0",
-                "symfony/finder": "^5.3|^6.0"
+                "symfony/filesystem": "^6.0",
+                "symfony/finder": "^6.0"
             },
             "conflict": {
-                "symplify/amnesia": "<9.4.70",
-                "symplify/astral": "<9.4.70",
-                "symplify/autowire-array-parameter": "<9.4.70",
-                "symplify/coding-standard": "<9.4.70",
-                "symplify/composer-json-manipulator": "<9.4.70",
-                "symplify/config-transformer": "<9.4.70",
-                "symplify/console-color-diff": "<9.4.70",
-                "symplify/console-package-builder": "<9.4.70",
-                "symplify/easy-ci": "<9.4.70",
-                "symplify/easy-coding-standard": "<9.4.70",
-                "symplify/easy-hydrator": "<9.4.70",
-                "symplify/easy-testing": "<9.4.70",
-                "symplify/git-wrapper": "<9.4.70",
-                "symplify/latte-phpstan-compiler": "<9.4.70",
-                "symplify/markdown-diff": "<9.4.70",
-                "symplify/monorepo-builder": "<9.4.70",
-                "symplify/package-builder": "<9.4.70",
-                "symplify/php-config-printer": "<9.4.70",
-                "symplify/phpstan-extensions": "<9.4.70",
-                "symplify/phpstan-rules": "<9.4.70",
-                "symplify/psr4-switcher": "<9.4.70",
-                "symplify/rule-doc-generator": "<9.4.70",
-                "symplify/rule-doc-generator-contracts": "<9.4.70",
-                "symplify/simple-php-doc-parser": "<9.4.70",
-                "symplify/skipper": "<9.4.70",
-                "symplify/symfony-php-config": "<9.4.70",
-                "symplify/symfony-static-dumper": "<9.4.70",
-                "symplify/symplify-kernel": "<9.4.70",
-                "symplify/template-phpstan-compiler": "<9.4.70",
-                "symplify/twig-phpstan-compiler": "<9.4.70",
-                "symplify/vendor-patches": "<9.4.70"
+                "symplify/astral": "<10.3.3",
+                "symplify/autowire-array-parameter": "<10.3.3",
+                "symplify/coding-standard": "<10.3.3",
+                "symplify/composer-json-manipulator": "<10.3.3",
+                "symplify/config-transformer": "<10.3.3",
+                "symplify/easy-ci": "<10.3.3",
+                "symplify/easy-coding-standard": "<10.3.3",
+                "symplify/easy-parallel": "<10.3.3",
+                "symplify/easy-testing": "<10.3.3",
+                "symplify/monorepo-builder": "<10.3.3",
+                "symplify/neon-config-dumper": "<10.3.3",
+                "symplify/package-builder": "<10.3.3",
+                "symplify/php-config-printer": "<10.3.3",
+                "symplify/phpstan-extensions": "<10.3.3",
+                "symplify/phpstan-rules": "<10.3.3",
+                "symplify/rule-doc-generator": "<10.3.3",
+                "symplify/rule-doc-generator-contracts": "<10.3.3",
+                "symplify/skipper": "<10.3.3",
+                "symplify/symfony-static-dumper": "<10.3.3",
+                "symplify/symplify-kernel": "<10.3.3",
+                "symplify/vendor-patches": "<10.3.3"
             },
             "require-dev": {
                 "nette/finder": "^2.5",
@@ -6966,7 +6920,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "9.5-dev"
+                    "dev-main": "10.4-dev"
                 }
             },
             "autoload": {
@@ -6980,7 +6934,7 @@
             ],
             "description": "Sanitized FileInfo with safe getRealPath() and other handy methods",
             "support": {
-                "source": "https://github.com/symplify/smart-file-system/tree/9.4.70"
+                "source": "https://github.com/symplify/smart-file-system/tree/10.3.3"
             },
             "funding": [
                 {
@@ -6992,60 +6946,50 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-10-02T16:06:51+00:00"
+            "time": "2022-06-13T14:03:57+00:00"
         },
         {
             "name": "symplify/symplify-kernel",
-            "version": "9.4.70",
+            "version": "10.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/symplify-kernel.git",
-                "reference": "c02be3838a59ec002e0a376be287c81547749b92"
+                "reference": "951838b8c4cee31c347a132755428c39437585c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/symplify-kernel/zipball/c02be3838a59ec002e0a376be287c81547749b92",
-                "reference": "c02be3838a59ec002e0a376be287c81547749b92",
+                "url": "https://api.github.com/repos/symplify/symplify-kernel/zipball/951838b8c4cee31c347a132755428c39437585c8",
+                "reference": "951838b8c4cee31c347a132755428c39437585c8",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.0",
-                "symfony/console": "^5.3|^6.0",
-                "symfony/dependency-injection": "^5.3|^6.0",
-                "symfony/http-kernel": "^5.3|^6.0",
-                "symplify/autowire-array-parameter": "^9.4.70",
-                "symplify/composer-json-manipulator": "^9.4.70",
-                "symplify/package-builder": "^9.4.70",
-                "symplify/smart-file-system": "^9.4.70"
+                "symfony/console": "^6.0",
+                "symfony/dependency-injection": "^6.0",
+                "symplify/autowire-array-parameter": "^10.3.3",
+                "symplify/composer-json-manipulator": "^10.3.3",
+                "symplify/package-builder": "^10.3.3",
+                "symplify/smart-file-system": "^10.3.3",
+                "webmozart/assert": "^1.10"
             },
             "conflict": {
-                "symplify/amnesia": "<9.4.70",
-                "symplify/astral": "<9.4.70",
-                "symplify/coding-standard": "<9.4.70",
-                "symplify/config-transformer": "<9.4.70",
-                "symplify/console-color-diff": "<9.4.70",
-                "symplify/console-package-builder": "<9.4.70",
-                "symplify/easy-ci": "<9.4.70",
-                "symplify/easy-coding-standard": "<9.4.70",
-                "symplify/easy-hydrator": "<9.4.70",
-                "symplify/easy-testing": "<9.4.70",
-                "symplify/git-wrapper": "<9.4.70",
-                "symplify/latte-phpstan-compiler": "<9.4.70",
-                "symplify/markdown-diff": "<9.4.70",
-                "symplify/monorepo-builder": "<9.4.70",
-                "symplify/php-config-printer": "<9.4.70",
-                "symplify/phpstan-extensions": "<9.4.70",
-                "symplify/phpstan-rules": "<9.4.70",
-                "symplify/psr4-switcher": "<9.4.70",
-                "symplify/rule-doc-generator": "<9.4.70",
-                "symplify/rule-doc-generator-contracts": "<9.4.70",
-                "symplify/simple-php-doc-parser": "<9.4.70",
-                "symplify/skipper": "<9.4.70",
-                "symplify/symfony-php-config": "<9.4.70",
-                "symplify/symfony-static-dumper": "<9.4.70",
-                "symplify/template-phpstan-compiler": "<9.4.70",
-                "symplify/twig-phpstan-compiler": "<9.4.70",
-                "symplify/vendor-patches": "<9.4.70"
+                "symplify/astral": "<10.3.3",
+                "symplify/coding-standard": "<10.3.3",
+                "symplify/config-transformer": "<10.3.3",
+                "symplify/easy-ci": "<10.3.3",
+                "symplify/easy-coding-standard": "<10.3.3",
+                "symplify/easy-parallel": "<10.3.3",
+                "symplify/easy-testing": "<10.3.3",
+                "symplify/monorepo-builder": "<10.3.3",
+                "symplify/neon-config-dumper": "<10.3.3",
+                "symplify/php-config-printer": "<10.3.3",
+                "symplify/phpstan-extensions": "<10.3.3",
+                "symplify/phpstan-rules": "<10.3.3",
+                "symplify/rule-doc-generator": "<10.3.3",
+                "symplify/rule-doc-generator-contracts": "<10.3.3",
+                "symplify/skipper": "<10.3.3",
+                "symplify/symfony-static-dumper": "<10.3.3",
+                "symplify/vendor-patches": "<10.3.3"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -7053,7 +6997,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "9.5-dev"
+                    "dev-main": "10.4-dev"
                 }
             },
             "autoload": {
@@ -7067,9 +7011,9 @@
             ],
             "description": "Internal Kernel for Symplify packages",
             "support": {
-                "source": "https://github.com/symplify/symplify-kernel/tree/9.4.70"
+                "source": "https://github.com/symplify/symplify-kernel/tree/10.3.3"
             },
-            "time": "2021-10-02T16:07:02+00:00"
+            "time": "2022-06-13T14:06:24+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -7410,16 +7354,16 @@
         },
         {
             "name": "fakerphp/faker",
-            "version": "v1.19.0",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FakerPHP/Faker.git",
-                "reference": "d7f08a622b3346766325488aa32ddc93ccdecc75"
+                "reference": "37f751c67a5372d4e26353bd9384bc03744ec77b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/d7f08a622b3346766325488aa32ddc93ccdecc75",
-                "reference": "d7f08a622b3346766325488aa32ddc93ccdecc75",
+                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/37f751c67a5372d4e26353bd9384bc03744ec77b",
+                "reference": "37f751c67a5372d4e26353bd9384bc03744ec77b",
                 "shasum": ""
             },
             "require": {
@@ -7446,7 +7390,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "v1.19-dev"
+                    "dev-main": "v1.20-dev"
                 }
             },
             "autoload": {
@@ -7471,9 +7415,9 @@
             ],
             "support": {
                 "issues": "https://github.com/FakerPHP/Faker/issues",
-                "source": "https://github.com/FakerPHP/Faker/tree/v1.19.0"
+                "source": "https://github.com/FakerPHP/Faker/tree/v1.20.0"
             },
-            "time": "2022-02-02T17:38:57+00:00"
+            "time": "2022-07-20T13:12:54+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -8897,72 +8841,6 @@
                 }
             ],
             "time": "2020-10-26T15:52:27+00:00"
-        },
-        {
-            "name": "sebastian/diff",
-            "version": "4.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3",
-                "symfony/process": "^4.2 || ^5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                }
-            ],
-            "description": "Diff implementation",
-            "homepage": "https://github.com/sebastianbergmann/diff",
-            "keywords": [
-                "diff",
-                "udiff",
-                "unidiff",
-                "unified diff"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-10-26T13:10:38+00:00"
         },
         {
             "name": "sebastian/environment",

--- a/configs/ecs.dist.php
+++ b/configs/ecs.dist.php
@@ -4,69 +4,87 @@ declare(strict_types=1);
 
 namespace Programic\QualityControl\EasyCodingStandard;
 
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $containerConfigurator->import(SetList::PSR_12);
-    $containerConfigurator->import(SetList::CLEAN_CODE);
+function ecsSets(): array
+{
+    return [SetList::PSR_12, SetList::CLEAN_CODE];
+}
 
-    $services = $containerConfigurator->services();
+function ecsRules(): array
+{
+    $rules = [];
 
     // phpcsfixer
-    $services->set(\PhpCsFixer\Fixer\Alias\MbStrFunctionsFixer::class);
-    $services->set(\PhpCsFixer\Fixer\Basic\BracesFixer::class);
-    $services->set(\PhpCsFixer\Fixer\ClassNotation\OrderedClassElementsFixer::class);
-    $services->set(\PhpCsFixer\Fixer\FunctionNotation\ReturnTypeDeclarationFixer::class);
-    $services->set(\PhpCsFixer\Fixer\Strict\StrictComparisonFixer::class);
-    $services->set(\PhpCsFixer\Fixer\Strict\StrictParamFixer::class);
+    $rules[] = \PhpCsFixer\Fixer\Alias\MbStrFunctionsFixer::class;
+    $rules[] = \PhpCsFixer\Fixer\Basic\BracesFixer::class;
+    $rules[] = \PhpCsFixer\Fixer\ClassNotation\OrderedClassElementsFixer::class;
+    $rules[] = \PhpCsFixer\Fixer\FunctionNotation\ReturnTypeDeclarationFixer::class;
+    $rules[] = \PhpCsFixer\Fixer\Strict\StrictComparisonFixer::class;
+    $rules[] = \PhpCsFixer\Fixer\Strict\StrictParamFixer::class;
 
     // slevomat
     // - arrays
-    $services->set(\SlevomatCodingStandard\Sniffs\Arrays\DisallowImplicitArrayCreationSniff::class);
-    $services->set(\SlevomatCodingStandard\Sniffs\Arrays\MultiLineArrayEndBracketPlacementSniff::class);
-    $services->set(\SlevomatCodingStandard\Sniffs\Arrays\SingleLineArrayWhitespaceSniff::class);
-    $services->set(\SlevomatCodingStandard\Sniffs\Arrays\TrailingArrayCommaSniff::class);
+    $rules[] = \SlevomatCodingStandard\Sniffs\Arrays\DisallowImplicitArrayCreationSniff::class;
+    $rules[] = \SlevomatCodingStandard\Sniffs\Arrays\MultiLineArrayEndBracketPlacementSniff::class;
+    $rules[] = \SlevomatCodingStandard\Sniffs\Arrays\SingleLineArrayWhitespaceSniff::class;
+    $rules[] = \SlevomatCodingStandard\Sniffs\Arrays\TrailingArrayCommaSniff::class;
+
     // - classes
-    $services->set(\SlevomatCodingStandard\Sniffs\Classes\ClassConstantVisibilitySniff::class);
-    $services->set(\SlevomatCodingStandard\Sniffs\Classes\DisallowMultiConstantDefinitionSniff::class);
-    $services->set(\SlevomatCodingStandard\Sniffs\Classes\DisallowMultiPropertyDefinitionSniff::class);
-    $services->set(\SlevomatCodingStandard\Sniffs\Classes\ModernClassNameReferenceSniff::class);
-    $services->set(\SlevomatCodingStandard\Sniffs\Classes\PropertyDeclarationSniff::class);
+    $rules[] = \SlevomatCodingStandard\Sniffs\Classes\ClassConstantVisibilitySniff::class;
+    $rules[] = \SlevomatCodingStandard\Sniffs\Classes\DisallowMultiConstantDefinitionSniff::class;
+    $rules[] = \SlevomatCodingStandard\Sniffs\Classes\DisallowMultiPropertyDefinitionSniff::class;
+    $rules[] = \SlevomatCodingStandard\Sniffs\Classes\ModernClassNameReferenceSniff::class;
+    $rules[] = \SlevomatCodingStandard\Sniffs\Classes\PropertyDeclarationSniff::class;
+
     // - control structures
-    $services->set(\SlevomatCodingStandard\Sniffs\ControlStructures\AssignmentInConditionSniff::class);
-    $services->set(\SlevomatCodingStandard\Sniffs\ControlStructures\DisallowContinueWithoutIntegerOperandInSwitchSniff::class);
-    $services->set(\SlevomatCodingStandard\Sniffs\ControlStructures\DisallowYodaComparisonSniff::class);
-    $services->set(\SlevomatCodingStandard\Sniffs\ControlStructures\NewWithParenthesesSniff::class);
-    $services->set(\SlevomatCodingStandard\Sniffs\ControlStructures\RequireNullCoalesceEqualOperatorSniff::class);
-    $services->set(\SlevomatCodingStandard\Sniffs\ControlStructures\RequireNullCoalesceOperatorSniff::class);
+    $rules[] = \SlevomatCodingStandard\Sniffs\ControlStructures\AssignmentInConditionSniff::class;
+    $rules[] = \SlevomatCodingStandard\Sniffs\ControlStructures\DisallowContinueWithoutIntegerOperandInSwitchSniff::class;
+    $rules[] = \SlevomatCodingStandard\Sniffs\ControlStructures\DisallowYodaComparisonSniff::class;
+    $rules[] = \SlevomatCodingStandard\Sniffs\ControlStructures\NewWithParenthesesSniff::class;
+    $rules[] = \SlevomatCodingStandard\Sniffs\ControlStructures\RequireNullCoalesceEqualOperatorSniff::class;
+    $rules[] = \SlevomatCodingStandard\Sniffs\ControlStructures\RequireNullCoalesceOperatorSniff::class;
+
     // - exceptions
-    $services->set(\SlevomatCodingStandard\Sniffs\Exceptions\DeadCatchSniff::class);
+    $rules[] = \SlevomatCodingStandard\Sniffs\Exceptions\DeadCatchSniff::class;
+
     // - functions
-    $services->set(\SlevomatCodingStandard\Sniffs\Functions\StrictCallSniff::class);
-    $services->set(\SlevomatCodingStandard\Sniffs\Functions\StaticClosureSniff::class);
-    $services->set(\SlevomatCodingStandard\Sniffs\Functions\UnusedParameterSniff::class);
-    $services->set(\SlevomatCodingStandard\Sniffs\Functions\UselessParameterDefaultValueSniff::class);
+    $rules[] = \SlevomatCodingStandard\Sniffs\Functions\StrictCallSniff::class;
+    $rules[] = \SlevomatCodingStandard\Sniffs\Functions\StaticClosureSniff::class;
+    $rules[] = \SlevomatCodingStandard\Sniffs\Functions\UnusedParameterSniff::class;
+    $rules[] = \SlevomatCodingStandard\Sniffs\Functions\UselessParameterDefaultValueSniff::class;
+
     // - namespaces
-    $services->set(\SlevomatCodingStandard\Sniffs\Namespaces\UseDoesNotStartWithBackslashSniff::class);
-    $services->set(\SlevomatCodingStandard\Sniffs\Namespaces\UselessAliasSniff::class);
+    $rules[] = \SlevomatCodingStandard\Sniffs\Namespaces\UseDoesNotStartWithBackslashSniff::class;
+    $rules[] = \SlevomatCodingStandard\Sniffs\Namespaces\UselessAliasSniff::class;
+
     // - php
-    $services->set(\SlevomatCodingStandard\Sniffs\PHP\ShortListSniff::class);
-    $services->set(\SlevomatCodingStandard\Sniffs\PHP\TypeCastSniff::class);
+    $rules[] = \SlevomatCodingStandard\Sniffs\PHP\ShortListSniff::class;
+    $rules[] = \SlevomatCodingStandard\Sniffs\PHP\TypeCastSniff::class;
+
+
     // - typehints
-    $services->set(\SlevomatCodingStandard\Sniffs\TypeHints\NullableTypeForNullDefaultValueSniff::class);
-    $services->set(\SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSniff::class);
-    $services->set(\SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSpacingSniff::class);
-    $services->set(\SlevomatCodingStandard\Sniffs\TypeHints\PropertyTypeHintSniff::class);
-    $services->set(\SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSniff::class);
-    $services->set(\SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSpacingSniff::class);
-    $services->set(\SlevomatCodingStandard\Sniffs\TypeHints\UselessConstantTypeHintSniff::class);
+    $rules[] = \SlevomatCodingStandard\Sniffs\TypeHints\NullableTypeForNullDefaultValueSniff::class;
+    $rules[] = \SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSniff::class;
+    $rules[] = \SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSpacingSniff::class;
+    $rules[] = \SlevomatCodingStandard\Sniffs\TypeHints\PropertyTypeHintSniff::class;
+    $rules[] = \SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSniff::class;
+    $rules[] = \SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSpacingSniff::class;
+    $rules[] = \SlevomatCodingStandard\Sniffs\TypeHints\UselessConstantTypeHintSniff::class;
+
+
     // - variables
-    $services->set(\SlevomatCodingStandard\Sniffs\Variables\DisallowSuperGlobalVariableSniff::class);
+    $rules[] = \SlevomatCodingStandard\Sniffs\Variables\DisallowSuperGlobalVariableSniff::class;
 
-    // - Programic specific rules
-//    $services->set(\ProgramicCodingStandards\Sniffs\Functions\ForceAttributeCastingSniff::class);
+    return $rules;
+}
 
-    $services->remove(\PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\RequireStrictTypesSniff::class);
-    $services->remove(\SlevomatCodingStandard\Sniffs\Functions\StaticClosureSniff::class);
-};
+function ecsSkips(): array
+{
+    $skips = [];
+
+    $skips[] = \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\RequireStrictTypesSniff::class;
+    $skips[] = \SlevomatCodingStandard\Sniffs\Functions\StaticClosureSniff::class;
+
+    return $skips;
+}

--- a/configs/examples/ecs.example.php
+++ b/configs/examples/ecs.example.php
@@ -1,17 +1,18 @@
 <?php
 
 declare(strict_types=1);
+require_once __DIR__ . '/vendor/programic/pro-backend-quality/configs/ecs.dist.php';
 
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use PHP_CodeSniffer\Standards\PSR12\Sniffs\Files\FileHeaderSniff;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 use Symplify\EasyCodingStandard\ValueObject\Option;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $containerConfigurator->import(__DIR__ . '/vendor/programic/pro-backend-quality/configs/ecs.dist.php');
+use function Programic\QualityControl\EasyCodingStandard\ecsRules;
+use function Programic\QualityControl\EasyCodingStandard\ecsSets;
+use function Programic\QualityControl\EasyCodingStandard\ecsSkips;
 
-    $parameters = $containerConfigurator->parameters();
-    $parameters->set(Option::PATHS, [
-        __DIR__,
-    ]);
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->paths([__DIR__]);
 
     $skips = [
         __DIR__ . '/vendor',
@@ -44,5 +45,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/app/Http/Middleware/Authenticate.php',
     ];
 
-    $parameters->set(Option::SKIP, $skips);
+    $ecsConfig->skip([...$skips, ...ecsSkips()]);
+
+    $ecsConfig->sets(ecsSets());
+
+    $ecsConfig->rules(ecsRules());
 };


### PR DESCRIPTION
Updated packages:

-  "symplify/coding-standard"  9.3 -> 10.0
-  "symplify/easy-coding-standard": 9.3 -> 10.1
-  "slevomat/coding-standard": 8.2 -> 8.3
-   "squizlabs/php_codesniffer": 3.6.2 -> 3.7.1

Had to make changes to the ecs.dist.php the ContainerConfigurator doesn't exists anymore.
We need to use the ECSConfig but this object doesn't has a importer function.
