### PR TITLE
Fix 'Backtrack limit was exhausted' problem'

### DIFF
--- a/configs/phpstan.dist.neon
+++ b/configs/phpstan.dist.neon
@@ -16,4 +16,5 @@ parameters:
         - %currentWorkingDirectory%/_ide_helper_models.php
 
     ignoreErrors:
-        - '#Property (.*)+ |Illuminate\Support\Collection<mixed, mixed>#'
+        - '#Property .* has no type specified.#'
+        - '#Illuminate\Support\Collection<mixed, mixed>#'


### PR DESCRIPTION
There was a backtrack (regex) problem in one of the ignoreErrors lines in phpstan.dist.neon.
The backtracking however was never used, so I removed the backtracking. Also there were 2 ignore attempts in the same line seperated by a pipe '|'. For simplicity I put each one of them on a seperate line.