### PR TITLE
Added excludePath _ide_helper_actions.php

### DIFF
--- a/configs/phpstan.dist.neon
+++ b/configs/phpstan.dist.neon
@@ -13,6 +13,7 @@ parameters:
         - %currentWorkingDirectory%/storage/*
         - %currentWorkingDirectory%/ecs.php
         - %currentWorkingDirectory%/_ide_helper.php
+        - %currentWorkingDirectory%/_ide_helper_actions.php
         - %currentWorkingDirectory%/_ide_helper_models.php
 
     ignoreErrors:


### PR DESCRIPTION
There is a package to generate ide-helpers for Laravel Actions: https://github.com/Wulfheart/laravel-actions-ide-helper

This generates a `_ide_helper_actions.php` file to provide code-completion. Unfortunately, phpstan does not like this file so it needs to be excluded for linting.